### PR TITLE
add specyfication for auditlogs

### DIFF
--- a/specification/auditlogs/data-model.md
+++ b/specification/auditlogs/data-model.md
@@ -1,0 +1,366 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Data Model
+weight: 2
+--->
+
+# Audit Logs Data Model
+
+**Status**: [Development](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+
+- [Design Notes](#design-notes)
+  * [Requirements](#requirements)
+  * [Tiered Processing Model](#tiered-processing-model)
+  * [Integrity and Verification Model](#integrity-and-verification-model)
+- [Audit Log Record Definition](#audit-log-record-definition)
+  * [Field: `Timestamp`](#field-timestamp)
+  * [Field: `ObservedTimestamp`](#field-observedtimestamp)
+  * [Field: `RecordId`](#field-recordid)
+  * [Field: `EventName`](#field-eventname)
+  * [Field: `Actor`](#field-actor)
+  * [Field: `ActorType`](#field-actortype)
+  * [Field: `Action`](#field-action)
+  * [Field: `Resource`](#field-resource)
+  * [Field: `Outcome`](#field-outcome)
+  * [Field: `SourceIp`](#field-sourceip)
+  * [Field: `Body`](#field-body)
+  * [Field: `Attributes`](#field-attributes)
+  * [Field: `SchemaVersion`](#field-schemaversion)
+  * [Integrity Fields](#integrity-fields)
+    + [Field: `Hash`](#field-hash)
+    + [Field: `Signature` / `Hmac`](#field-signature--hmac)
+    + [Field: `HashAlgorithm`](#field-hashalgorithm)
+    + [Field: `KeyId`](#field-keyid)
+  * [Optional Ordering Fields](#optional-ordering-fields)
+    + [Field: `SequenceNo`](#field-sequenceno)
+    + [Field: `PrevHash`](#field-prevhash)
+- [Tier-1 Response Model](#tier-1-response-model)
+  * [Single-Record Response Fields](#single-record-response-fields)
+  * [Batch Response Fields](#batch-response-fields)
+  * [Recommended Tier-1 HTTP Status Codes](#recommended-tier-1-http-status-codes)
+- [Tier-2 Verification and Delivery Model](#tier-2-verification-and-delivery-model)
+  * [Tier-2 Domain Statuses](#tier-2-domain-statuses)
+  * [Verify Processor Output Fields](#verify-processor-output-fields)
+  * [Per-Sink Delivery Status Fields](#per-sink-delivery-status-fields)
+  * [Recommended Tier-2 HTTP Status Codes](#recommended-tier-2-http-status-codes)
+- [Tier-2 Record Lifecycle](#tier-2-record-lifecycle)
+- [References](#references)
+
+<!-- tocstop -->
+
+</details>
+
+This document defines a data model for audit logs that can be used across
+application producers (Tier-1) and collector-side verification and distribution
+pipelines (Tier-2).
+
+The model extends the OpenTelemetry logs signal with audit-specific identity,
+integrity, and delivery semantics so that both security and operational behavior
+are represented in a consistent way.
+
+## Design Notes
+
+### Requirements
+
+The audit logs data model is designed to satisfy the following requirements:
+
+- It should capture core audit semantics consistently: who did what, to which
+  resource, when, and with what result.
+- It should preserve end-to-end integrity metadata (hash and signature/HMAC)
+  and allow deterministic verification.
+- It should support both single-record and batch processing.
+- It should support synchronous and asynchronous delivery models without losing
+  auditability.
+- It should support clear failure and retry outcomes suitable for policy and
+  forensics.
+
+### Tiered Processing Model
+
+This model assumes two logical tiers:
+
+- **Tier-1** receives audit events from producers, applies initial processing,
+  and forwards to Tier-2.
+- **Tier-2** performs verification, routing, and exporter delivery tracking to
+  required sinks.
+
+Both tiers may expose response metadata. Tier-1 responses focus on immediate
+acceptance or queueing behavior. Tier-2 responses focus on verification and
+delivery state.
+
+### Integrity and Verification Model
+
+Audit events should include integrity fields that allow content authenticity
+checks:
+
+- `Hash` of canonical payload.
+- `Signature` or `Hmac`.
+- `HashAlgorithm`, `SchemaVersion`, and optional `KeyId`.
+
+For stronger sequence tamper evidence, implementations may include
+`SequenceNo` and `PrevHash` to enable hash chain validation.
+
+## Audit Log Record Definition
+
+Here is the list of fields in an audit log record:
+
+| Field Name | Description |
+| ---------- | ----------- |
+| Timestamp | Time when the audited action occurred. |
+| ObservedTimestamp | Time when Tier-1 observed the record. |
+| RecordId | Unique identifier for the record. |
+| EventName | Name identifying audit event type. |
+| Actor | Principal that performed the action. |
+| ActorType | Classification of actor (for example user, service, system). |
+| Action | Action performed by the actor. |
+| Resource | Target resource of the action. |
+| Outcome | Result of the action (for example success, failure, denied). |
+| SourceIp | Source network address for the action if available. |
+| Body | Event payload. |
+| Attributes | Additional structured metadata. |
+| SchemaVersion | Version of the audit payload schema. |
+| Hash | Integrity hash of canonical payload. |
+| Signature / Hmac | Cryptographic authenticity proof. |
+| HashAlgorithm | Algorithm used to compute hash. |
+| KeyId | Identifier of signing key, if applicable. |
+| SequenceNo | Optional sequence number for chain continuity. |
+| PrevHash | Optional previous record hash for hash chain continuity. |
+
+Below is the detailed description of each field.
+
+### Field: `Timestamp`
+
+Type: Timestamp, uint64 nanoseconds since UNIX epoch.
+
+Description: Time when the audited event occurred at the source.
+
+### Field: `ObservedTimestamp`
+
+Type: Timestamp, uint64 nanoseconds since UNIX epoch.
+
+Description: Time when the record was first observed by Tier-1.
+
+### Field: `RecordId`
+
+Type: string.
+
+Description: Unique immutable record identifier. It is required for retries,
+status reporting, deduplication, and Tier-1/Tier-2 correlation.
+
+### Field: `EventName`
+
+Type: string.
+
+Description: Name identifying the event type. This should remain stable for a
+given event schema.
+
+### Field: `Actor`
+
+Type: string or structured object encoded in [AnyValue](../common/README.md#anyvalue).
+
+Description: Identity of the principal that executed the action.
+
+### Field: `ActorType`
+
+Type: string.
+
+Description: Actor class such as `user`, `service`, or `system`.
+
+### Field: `Action`
+
+Type: string.
+
+Description: Canonical verb describing the operation performed.
+
+### Field: `Resource`
+
+Type: [AnyValue](../common/README.md#anyvalue) or [Attribute Collection](../common/README.md#attribute-collections).
+
+Description: Target object of the audit event, such as account, dataset,
+endpoint, or configuration object.
+
+### Field: `Outcome`
+
+Type: string.
+
+Description: Event result, for example `success`, `failure`, or `denied`.
+
+### Field: `SourceIp`
+
+Type: string.
+
+Description: Source IP address or equivalent network origin identifier when
+available.
+
+### Field: `Body`
+
+Type: [AnyValue](../common/README.md#anyvalue).
+
+Description: Main payload for the audit record, potentially including structured
+details specific to the event type.
+
+### Field: `Attributes`
+
+Type: [Attribute Collection](../common/README.md#attribute-collections).
+
+Description: Additional context fields not represented as top-level fields.
+
+### Field: `SchemaVersion`
+
+Type: string.
+
+Description: Schema version of canonical payload used for validation and
+verification.
+
+### Integrity Fields
+
+#### Field: `Hash`
+
+Type: string.
+
+Description: Digest of canonical event payload for integrity validation.
+
+#### Field: `Signature` / `Hmac`
+
+Type: string or byte sequence.
+
+Description: Source-authenticated cryptographic proof. Implementations may use
+signature or HMAC depending on trust model and key management strategy.
+
+#### Field: `HashAlgorithm`
+
+Type: string.
+
+Description: Hash algorithm identifier used for `Hash` (for example `sha256`).
+
+#### Field: `KeyId`
+
+Type: string.
+
+Description: Optional key identifier used to verify `Signature` or `Hmac`.
+
+### Optional Ordering Fields
+
+#### Field: `SequenceNo`
+
+Type: integer.
+
+Description: Optional sequence number used for ordered processing and chain
+continuity.
+
+#### Field: `PrevHash`
+
+Type: string.
+
+Description: Optional hash pointer to previous record in a chain.
+
+## Tier-1 Response Model
+
+Tier-1 responses communicate immediate intake outcome and initial delivery or
+queueing status.
+
+### Single-Record Response Fields
+
+- `record_id`
+- `status_code`
+- `status` (for example `delivered`, `queued`, `rejected`)
+- `hash`
+- `sink_timestamp` when synchronously delivered
+- `reason` when non-success
+- `retry_after` when queueing or backpressure applies
+
+### Batch Response Fields
+
+- `batch_id`
+- `status_code`
+- `hash` (batch hash or root when used)
+- `sink_timestamp`
+- `log_status_map`
+
+### Recommended Tier-1 HTTP Status Codes
+
+- `200` sent now.
+- `202` stored for later processing.
+- `400` invalid payload or schema.
+- `401` or `403` authentication or authorization failure.
+- `413` payload too large.
+- `429` too many requests when quota policies are enabled.
+- `500` unexpected internal failure.
+- `503` cannot accept due to capacity constraints.
+
+## Tier-2 Verification and Delivery Model
+
+Tier-2 response semantics should represent verification and per-sink delivery
+status, not only transport-level outcomes.
+
+### Tier-2 Domain Statuses
+
+- `accepted_pending_verify`
+- `verified_queued`
+- `verified_exporting`
+- `delivered_all_sinks`
+- `delivered_partial`
+- `rejected_verify_failed`
+- `rejected_schema_invalid`
+- `rejected_authz`
+- `failed_internal`
+
+### Verify Processor Output Fields
+
+For each record:
+
+- `verify_status` (`passed`, `failed`, `deferred`)
+- `verify_reason`
+- `verify_details`
+- `verified_at`
+- `verification_profile`
+
+### Per-Sink Delivery Status Fields
+
+For each required sink:
+
+- `exporter_name`
+- `sink_type`
+- `delivery_status` (`success`, `failed`, `timeout`, `retrying`, `unknown`)
+- `attempt_count`
+- `last_attempt_at`
+- `sink_ack_id`
+- `error_code`
+- `error_message`
+
+Record outcome is successful only when every required sink reports `success`.
+
+### Recommended Tier-2 HTTP Status Codes
+
+- `200` fully processed and all required sinks confirmed.
+- `202` accepted for async verify or export.
+- `207` optional mixed sink results; treat as non-success.
+- `400` malformed payload or canonicalization failure.
+- `401` or `403` authentication or authorization failure.
+- `409` conflicting duplicate `record_id`.
+- `413` payload too large.
+- `429` intake throttled by policy.
+- `500` unexpected Tier-2 failure.
+- `503` temporary unavailability or no reliable intake capacity.
+
+## Tier-2 Record Lifecycle
+
+Recommended state transitions:
+
+`received -> accepted_pending_verify -> verified_queued -> verified_exporting -> delivered_all_sinks`
+
+Alternative terminal states:
+
+- `rejected_schema_invalid`
+- `rejected_verify_failed`
+- `rejected_authz`
+- `delivered_partial`
+- `failed_internal`
+
+## References
+
+- Tier-1 Audit Log Processing and Security Proposals.
+- Tier-2 AuditLog Endpoint Processing and Verification Proposals.

--- a/specification/auditlogs/sdk.md
+++ b/specification/auditlogs/sdk.md
@@ -1,0 +1,350 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: SDK
+weight: 3
+--->
+
+# Audit Logs SDK
+
+**Status**: [Development](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+
+- [AuditLoggerProvider](#auditloggerprovider)
+  * [AuditLoggerProvider Creation](#auditloggerprovider-creation)
+  * [AuditLogger Creation](#auditlogger-creation)
+  * [Configuration](#configuration)
+  * [Shutdown](#shutdown)
+  * [ForceFlush](#forceflush)
+- [AuditLogger](#auditlogger)
+  * [Emit an AuditRecord](#emit-an-auditrecord)
+  * [Enabled](#enabled)
+- [Additional AuditRecord interfaces](#additional-auditrecord-interfaces)
+  * [ReadableAuditRecord](#readableauditrecord)
+  * [ReadWriteAuditRecord](#readwriteauditrecord)
+- [AuditRecord Limits](#auditrecord-limits)
+- [AuditRecordProcessor](#auditrecordprocessor)
+  * [AuditRecordProcessor operations](#auditrecordprocessor-operations)
+    + [OnEmit](#onemit)
+    + [Enabled](#enabled-1)
+    + [Shutdown](#shutdown-1)
+    + [ForceFlush](#forceflush-1)
+  * [Built-in processors](#built-in-processors)
+    + [Single processor (sync)](#single-processor-sync)
+    + [Single processor (async)](#single-processor-async)
+    + [Batching processor (async)](#batching-processor-async)
+- [AuditRecordExporter](#auditrecordexporter)
+  * [AuditRecordExporter operations](#auditrecordexporter-operations)
+    + [Export](#export)
+    + [ForceFlush](#forceflush-2)
+    + [Shutdown](#shutdown-2)
+- [Tier-1 to Tier-2 Response Semantics](#tier-1-to-tier-2-response-semantics)
+- [Concurrency requirements](#concurrency-requirements)
+- [References](#references)
+
+<!-- tocstop -->
+
+</details>
+
+This document defines SDK behavior for Tier-1 audit logging where the
+application emits audit records and the SDK processes and exports them to Tier-2
+for verification and sink delivery.
+
+The SDK defined here follows the OpenTelemetry Logs SDK model while adding
+audit-specific processing and status semantics.
+
+## AuditLoggerProvider
+
+An `AuditLoggerProvider` MUST provide a way to set a
+[Resource](../resource/sdk.md). If a `Resource` is specified, it SHOULD be
+associated with all emitted audit records.
+
+### AuditLoggerProvider Creation
+
+The SDK SHOULD allow creation of multiple independent `AuditLoggerProvider`
+instances.
+
+### AuditLogger Creation
+
+It SHOULD only be possible to create `AuditLogger` instances through an
+`AuditLoggerProvider`.
+
+The user input MUST be used to create an
+[`InstrumentationScope`](../common/instrumentation-scope.md) associated with the
+created `AuditLogger`.
+
+If an invalid logger name is supplied, the SDK MUST return a working fallback
+logger and SHOULD log an internal diagnostic message.
+
+### Configuration
+
+`AuditRecordProcessor` and `AuditRecordExporter` configuration MUST be owned by
+the `AuditLoggerProvider`.
+
+If configuration is updated, the update MUST apply to all previously created
+`AuditLogger` instances and new `AuditLogger` instances.
+
+### Shutdown
+
+`Shutdown` MUST be called only once per `AuditLoggerProvider`.
+
+After `Shutdown`, attempts to get an `AuditLogger` SHOULD return a valid no-op
+logger if possible.
+
+`Shutdown` MUST invoke `Shutdown` on all registered
+[`AuditRecordProcessor`](#auditrecordprocessor) instances.
+
+### ForceFlush
+
+`ForceFlush` notifies all registered processors to immediately process and
+export records already accepted by the SDK.
+
+`ForceFlush` MUST invoke `ForceFlush` on all registered processors.
+
+If immediate send to Tier-2 is not possible because of temporary transport or
+capacity failures, the SDK SHOULD persist records in configured storage for
+later processing and retry.
+
+## AuditLogger
+
+### Emit an AuditRecord
+
+When emitting an audit record, the SDK SHOULD ensure
+[`ObservedTimestamp`](./data-model.md#field-observedtimestamp) is set to current
+time if it is missing.
+
+The SDK MUST preserve required Tier-1 fields from the
+[Audit Logs Data Model](./data-model.md#audit-log-record-definition):
+`Timestamp`, `ObservedTimestamp`, `EventName`, `Actor`, `ActorType`, `Outcome`,
+`Resource`, `Action`, `SourceIp`, `Body`, `Attributes`, `RecordId`, `Hash`,
+`Signature` or `Hmac`, and `SchemaVersion`.
+
+The SDK SHOULD preserve implementation-dependent fields when provided:
+`TenantId` or `ServiceName`, `SequenceNo`, `PrevHash`, `HashAlgorithm`, and
+`KeyId`.
+
+If a required field is missing, the record MUST be rejected by SDK processing
+or marked with failure status according to processor policy.
+
+### Enabled
+
+`Enabled` SHOULD return `false` when:
+
+- no processors are registered.
+- provider is shut down.
+- all processors that implement `Enabled` return `false`.
+
+Otherwise it SHOULD return `true`.
+
+## Additional AuditRecord interfaces
+
+### ReadableAuditRecord
+
+A function receiving a `ReadableAuditRecord` MUST be able to read:
+
+- all fields from the [Audit Logs Data Model](./data-model.md).
+- associated `Resource`.
+- associated `InstrumentationScope`.
+
+### ReadWriteAuditRecord
+
+`ReadWriteAuditRecord` is a superset of `ReadableAuditRecord`.
+
+A function receiving a `ReadWriteAuditRecord` MUST be able to modify at least:
+
+- `Timestamp`
+- `ObservedTimestamp`
+- `EventName`
+- `Body`
+- `Attributes`
+- `Outcome`
+- `Hash`
+- `Signature` or `Hmac`
+- `HashAlgorithm`
+- `KeyId`
+
+SDKs MAY provide cloning for asynchronous processing to avoid race conditions.
+
+## AuditRecord Limits
+
+Audit record attributes MUST follow
+[common attribute limit rules](../common/README.md#attribute-limits).
+
+If limits are implemented, SDKs SHOULD provide configurable parameters for
+attribute count and value length limits.
+
+## AuditRecordProcessor
+
+`AuditRecordProcessor` defines hooks for record processing before export.
+
+Processors can perform validation, canonicalization, integrity preparation, and
+routing decisions.
+
+Processors registered on `AuditLoggerProvider` MUST be invoked in registration
+order.
+
+### AuditRecordProcessor operations
+
+#### OnEmit
+
+`OnEmit` is called synchronously when an audit record is emitted.
+
+`OnEmit` SHOULD NOT block for long operations and SHOULD NOT throw exceptions.
+
+**Parameters:**
+
+- `auditRecord` - a [ReadWriteAuditRecord](#readwriteauditrecord).
+- `context` - resolved [Context](../context/README.md).
+
+For processors registered directly on the provider, mutations made by one
+processor MUST be visible to next processors in order.
+
+#### Enabled
+
+`Enabled` is optional and supports pre-filter checks.
+
+**Parameters:**
+
+- resolved [Context](../context/README.md)
+- [InstrumentationScope](../common/instrumentation-scope.md)
+- event name
+
+**Returns:** `Boolean`
+
+If indeterminate, implementation SHOULD default to `true`.
+
+#### Shutdown
+
+`Shutdown` is called when SDK shuts down and SHOULD execute cleanup.
+
+After `Shutdown`, calls to `OnEmit` SHOULD be ignored gracefully.
+
+`Shutdown` SHOULD include effects of `ForceFlush`.
+
+#### ForceFlush
+
+`ForceFlush` is a hint to complete pending processing and export for records
+accepted before the call.
+
+If timeout is configured, processors MUST prioritize honoring timeout.
+
+If processors cannot complete export because of temporary transport or capacity
+failures, they SHOULD persist pending records to configured storage for later
+processing and retry.
+
+### Built-in processors
+
+The standard audit SDK SHOULD implement the three processors below.
+
+#### Single processor (sync)
+
+Processes one record and exports immediately in the caller path.
+
+This processor provides strongest immediate delivery signal but increases caller
+latency.
+
+**Configurable parameters:**
+
+- `exporter`
+- `exportTimeoutMillis`
+
+#### Single processor (async)
+
+Processes one record at a time asynchronously using queue or storage.
+
+This processor reduces request-path latency and supports retries.
+
+**Configurable parameters:**
+
+- `exporter`
+- `maxQueueSize`
+- `exportTimeoutMillis`
+- `maxRetryCount`
+- `initialBackoffMillis`
+
+#### Batching processor (async)
+
+Builds batches for asynchronous export to improve throughput and efficiency.
+
+**Configurable parameters:**
+
+- `exporter`
+- `maxQueueSize`
+- `scheduledDelayMillis`
+- `exportTimeoutMillis`
+- `maxExportBatchSize`
+- `maxRetryCount`
+- `initialBackoffMillis`
+
+## AuditRecordExporter
+
+`AuditRecordExporter` defines exporter behavior from Tier-1 SDK to Tier-2
+ingress endpoint.
+
+Exporters SHOULD support protocol-specific details such as OTLP transport,
+authn/authz headers, and TLS/mTLS configuration.
+
+### AuditRecordExporter operations
+
+An `AuditRecordExporter` MUST support the following operations.
+
+#### Export
+
+`Export` sends a batch of `ReadableAuditRecord` to Tier-2.
+
+`Export` MUST NOT be called concurrently for the same exporter instance.
+
+`Export` MUST NOT block indefinitely and MUST complete with bounded timeout.
+
+**Returns:** `ExportResult`
+
+`ExportResult` MUST represent success or failure for transport-level submission.
+If protocol allows, exporters SHOULD propagate detailed response payloads from
+Tier-2.
+
+#### ForceFlush
+
+`ForceFlush` is a hint to complete export of records already received by the
+exporter.
+
+#### Shutdown
+
+`Shutdown` is called once per exporter instance. After shutdown, `Export` calls
+SHOULD return failure.
+
+## Tier-1 to Tier-2 Response Semantics
+
+Tier-1 SDK processors and exporters SHOULD interpret response status using both:
+
+- transport-level HTTP status code.
+- domain-level status fields in response body when available.
+
+Tier-1 behavior SHOULD treat success conservatively:
+
+- `200` may be treated as immediate delivered success.
+- `202` means accepted or queued, not fully delivered.
+- `207` or `delivered_partial` MUST be treated as non-success final outcome.
+- `429` and `503` SHOULD trigger retry behavior when policy allows.
+- `400`, `401`, `403`, `409`, and `413` SHOULD be treated as non-retryable
+  unless implementation policy explicitly says otherwise.
+
+For required field expectations and status fields, see
+[Audit Logs Data Model](./data-model.md#tier-1-response-model) and
+[Tier-2 verification model](./data-model.md#tier-2-verification-and-delivery-model).
+
+## Concurrency requirements
+
+For languages with concurrent execution support:
+
+- **AuditLoggerProvider**: logger creation, `ForceFlush`, and `Shutdown` MUST be
+  safe for concurrent use.
+- **AuditLogger**: all methods MUST be safe for concurrent use.
+- **AuditRecordExporter**: `ForceFlush` and `Shutdown` MUST be safe for
+  concurrent use.
+
+## References
+
+- [Audit Logs Data Model](./data-model.md)
+- [OpenTelemetry Logs SDK](../logs/sdk.md)

--- a/specification/auditlogs/tier1-api.md
+++ b/specification/auditlogs/tier1-api.md
@@ -1,0 +1,192 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Tier-1 API
+weight: 1
+aliases: [audit-bridge-api]
+--->
+
+# Audit Logs Tier-1 API
+
+**Status**: [Development](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [AuditLoggerProvider](#auditloggerprovider)
+  * [AuditLoggerProvider operations](#auditloggerprovider-operations)
+    + [Get an AuditLogger](#get-an-auditlogger)
+- [AuditLogger](#auditlogger)
+  * [Emit an AuditRecord](#emit-an-auditrecord)
+  * [Enabled](#enabled)
+- [Optional and required parameters](#optional-and-required-parameters)
+- [Concurrency requirements](#concurrency-requirements)
+- [Ergonomic API](#ergonomic-api)
+- [References](#references)
+
+<!-- tocstop -->
+
+</details>
+
+The Audit Logs API is provided for instrumentation and logging library authors
+to emit structured audit records that follow the
+[Audit Logs Data Model](./data-model.md).
+
+The API can be used directly by applications or indirectly via adapters and
+bridges. Languages may provide a more [ergonomic API](#ergonomic-api) for direct
+usage.
+
+This API specifies Tier-1 behavior only (application and SDK emit path). Tier-2
+collector verification and delivery behavior is out of scope for this document
+and is defined in [Audit Logs Data Model](./data-model.md) and
+[Audit Logs SDK](./sdk.md).
+
+The Audit Logs API consists of these main components:
+
+* [AuditLoggerProvider](#auditloggerprovider) is the entry point of the API.
+  It provides access to `AuditLogger` instances.
+* [AuditLogger](#auditlogger) is responsible for emitting
+  [AuditRecord](./data-model.md#audit-log-record-definition).
+
+```mermaid
+graph TD
+    A[AuditLoggerProvider] -->|Get| B(AuditLogger)
+    B -->|Emit| C(AuditRecord)
+```
+
+## AuditLoggerProvider
+
+`AuditLogger` instances are accessed with an `AuditLoggerProvider`.
+
+The API SHOULD provide a way to register and access a global default
+`AuditLoggerProvider`.
+
+### AuditLoggerProvider operations
+
+The `AuditLoggerProvider` MUST provide the following function:
+
+* Get an `AuditLogger`
+
+#### Get an AuditLogger
+
+This API MUST accept the following
+[instrumentation scope](../common/instrumentation-scope.md) parameters:
+
+* `name`: Name of the instrumentation scope, such as instrumentation library,
+  package, module, class, or component name.
+* `version` (optional): Version of the instrumentation scope.
+* `schema_url` (optional): Schema URL to record on emitted telemetry.
+* `attributes` (optional): Instrumentation scope attributes associated with
+  emitted telemetry.
+
+The term *identical* applied to `AuditLogger` instances describes instances
+where all parameters are equal. The term *distinct* applied to `AuditLogger`
+instances describes instances where at least one parameter is different.
+
+## AuditLogger
+
+The `AuditLogger` is responsible for emitting `AuditRecord` values.
+
+The `AuditLogger` MUST provide a function to:
+
+- [Emit an `AuditRecord`](#emit-an-auditrecord)
+
+The `AuditLogger` SHOULD provide functions to:
+
+- [Report if `AuditLogger` is `Enabled`](#enabled)
+
+### Emit an AuditRecord
+
+The effect of calling this API is to emit an `AuditRecord` to the processing
+pipeline.
+
+The API MUST accept the following parameters:
+
+- [Timestamp](./data-model.md#field-timestamp) (required)
+- [ObservedTimestamp](./data-model.md#field-observedtimestamp) (optional)
+- The [Context](../context/README.md) associated with the `AuditRecord`.
+  When implicit Context is supported, this parameter SHOULD be optional and
+  if unspecified then MUST use current Context.
+  When only explicit Context is supported, this parameter SHOULD be required.
+- [RecordId](./data-model.md#field-recordid) (required)
+- [EventName](./data-model.md#field-eventname) (required)
+- [Actor](./data-model.md#field-actor) (required)
+- [ActorType](./data-model.md#field-actortype) (required)
+- [Action](./data-model.md#field-action) (required)
+- [Resource](./data-model.md#field-resource) (required)
+- [Outcome](./data-model.md#field-outcome) (required)
+- [SourceIp](./data-model.md#field-sourceip) (optional)
+- [Body](./data-model.md#field-body) (required)
+- [Attributes](./data-model.md#field-attributes) (required)
+- [SchemaVersion](./data-model.md#field-schemaversion) (required)
+- [Hash](./data-model.md#field-hash) (required)
+- [Signature/Hmac](./data-model.md#field-signature--hmac) (required)
+
+The API MAY accept the following parameters:
+
+- [HashAlgorithm](./data-model.md#field-hashalgorithm) (optional)
+- [KeyId](./data-model.md#field-keyid) (optional)
+- [SequenceNo](./data-model.md#field-sequenceno) (optional)
+- [PrevHash](./data-model.md#field-prevhash) (optional)
+
+### Enabled
+
+To help users avoid computationally expensive work when generating an
+`AuditRecord`, an `AuditLogger` SHOULD provide this `Enabled` API.
+
+The API SHOULD accept the following parameters:
+
+- The [Context](../context/README.md) to be associated with the `AuditRecord`.
+  When implicit Context is supported, this parameter SHOULD be optional and
+  if unspecified then MUST use current Context.
+  When only explicit Context is supported, accepting this parameter is required.
+- [EventName](./data-model.md#field-eventname) (optional)
+
+This API MUST return a language-idiomatic boolean type.
+
+A returned value of `true` means the `AuditLogger` is enabled for the provided
+arguments, and a returned value of `false` means it is disabled for the provided
+arguments.
+
+The returned value can change over time, so instrumentation authors SHOULD call
+this API each time they [emit an AuditRecord](#emit-an-auditrecord) to ensure an
+up-to-date response.
+
+## Optional and required parameters
+
+The operations defined include various parameters, some marked optional.
+Parameters not marked optional are required.
+
+For each optional parameter, the API MUST accept it but MUST NOT require users
+to provide it.
+
+For each required parameter, the API MUST require users to provide it.
+
+## Concurrency requirements
+
+For languages that support concurrent execution, the Audit Logs API provides
+specific guarantees and safeties.
+
+**AuditLoggerProvider** - all methods MUST be documented as safe for concurrent
+use by default.
+
+**AuditLogger** - all methods MUST be documented as safe for concurrent use by
+default.
+
+## Ergonomic API
+
+Languages MAY additionally provide a more ergonomic and convenient API for
+emitting audit records.
+
+The ergonomic API SHOULD simplify common audit logging patterns while preserving
+the core required fields and integrity semantics defined in this document.
+
+The ergonomic API design SHOULD be idiomatic for its language.
+
+## References
+
+- [Audit Logs Data Model](./data-model.md)
+- [Audit Logs SDK](./sdk.md)
+- [OpenTelemetry Logs API](../logs/api.md)

--- a/specification/auditlogs/tier2-api.md
+++ b/specification/auditlogs/tier2-api.md
@@ -1,0 +1,219 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Tier-2 API
+weight: 4
+--->
+
+# Audit Logs Tier-2 API
+
+**Status**: [Development](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+
+- [Overview](#overview)
+- [Endpoint Scope](#endpoint-scope)
+- [Endpoint Definition](#endpoint-definition)
+  * [Single-Record Ingest](#single-record-ingest)
+  * [Batch Ingest](#batch-ingest)
+- [Request Model](#request-model)
+  * [Required Record Fields](#required-record-fields)
+  * [Optional Record Fields](#optional-record-fields)
+- [Response Model](#response-model)
+  * [Single-Record Response Fields](#single-record-response-fields)
+  * [Batch Response Fields](#batch-response-fields)
+  * [Tier-2 Domain Status Values](#tier-2-domain-status-values)
+- [HTTP Status Codes](#http-status-codes)
+- [Idempotency and Duplicate Handling](#idempotency-and-duplicate-handling)
+- [Verification and Sink Delivery Semantics](#verification-and-sink-delivery-semantics)
+- [Retry Guidance](#retry-guidance)
+- [Security Requirements](#security-requirements)
+- [References](#references)
+
+<!-- tocstop -->
+
+</details>
+
+## Overview
+
+This document specifies the Tier-2 collector ingress endpoint for audit logs.
+It defines API behavior for receiving `auditLog` records from Tier-1 and
+returning transport and domain-level processing outcomes.
+
+## Endpoint Scope
+
+This API is Tier-2 only. It covers collector ingress behavior and response
+semantics for verification and sink delivery tracking.
+
+Tier-1 emit behavior is defined in:
+
+- [Audit Logs Tier-1 API](./tier1-api.md)
+- [Audit Logs SDK](./sdk.md)
+
+## Endpoint Definition
+
+The Tier-2 endpoint MUST support ingesting audit records in single-record and
+batch modes.
+
+### Single-Record Ingest
+
+- **Path**: implementation defined (`/v1/auditlog` is recommended).
+- **Method**: `POST`.
+- **Body**: one audit record payload.
+
+### Batch Ingest
+
+- **Path**: implementation defined (`/v1/auditlogs` is recommended).
+- **Method**: `POST`.
+- **Body**: batch payload containing multiple audit records.
+
+## Request Model
+
+Request payloads MUST follow the [Audit Logs Data Model](./data-model.md).
+
+### Required Record Fields
+
+Each record MUST include:
+
+- `timestamp`
+- `record_id`
+- `event_name`
+- `actor`
+- `actor_type`
+- `action`
+- `resource`
+- `outcome`
+- `body`
+- `attributes`
+- `schema_version`
+- `hash`
+- `signature` or `hmac`
+
+### Optional Record Fields
+
+Each record MAY include:
+
+- `observed_timestamp`
+- `source_ip`
+- `hash_algorithm`
+- `key_id`
+- `sequence_no`
+- `prev_hash`
+
+## Response Model
+
+Tier-2 responses MUST include:
+
+- transport-level HTTP status code.
+- domain-level Tier-2 processing status.
+
+### Single-Record Response Fields
+
+- `record_id`
+- `http_status_code`
+- `tier2_status`
+- `verify_status`
+- `hash`
+- `received_at`
+- `processed_at`
+- `required_sinks`
+- `sink_status_map`
+- `reason`
+- `retry_after` (when relevant)
+
+### Batch Response Fields
+
+- `batch_id`
+- `http_status_code`
+- `tier2_status`
+- `batch_summary`
+- `record_status_map`
+- `sink_status_aggregate`
+
+### Tier-2 Domain Status Values
+
+Tier-2 SHOULD use the following domain status values:
+
+- `accepted_pending_verify`
+- `verified_queued`
+- `verified_exporting`
+- `delivered_all_sinks`
+- `delivered_partial`
+- `rejected_verify_failed`
+- `rejected_schema_invalid`
+- `rejected_authz`
+- `failed_internal`
+
+## HTTP Status Codes
+
+Tier-2 SHOULD use the following HTTP status codes:
+
+- `200` fully processed synchronously with all required sinks confirmed.
+- `202` accepted for asynchronous verify/export, final state pending.
+- `207` optional for mixed sink outcomes (`delivered_partial`), non-success.
+- `400` malformed payload, schema mismatch, or canonicalization error.
+- `401` or `403` authentication or authorization failure.
+- `409` duplicate `record_id` with incompatible payload hash.
+- `413` payload too large.
+- `429` intake throttled by policy.
+- `500` unexpected internal error.
+- `503` temporarily unavailable or no reliable intake capacity.
+
+## Idempotency and Duplicate Handling
+
+Tier-2 MUST treat `record_id` as the primary idempotency key.
+
+When a duplicate `record_id` is received:
+
+- if canonical payload hash is identical, endpoint SHOULD return a deterministic
+  idempotent response for existing record state.
+- if canonical payload hash differs, endpoint MUST return conflict (`409`).
+
+## Verification and Sink Delivery Semantics
+
+Tier-2 MUST separate acceptance from final delivery state.
+
+- `202` means accepted for processing, not fully delivered.
+- `delivered_all_sinks` means every required sink has reported `success`.
+- `delivered_partial` means at least one required sink is non-success and MUST
+  be treated as non-success final outcome.
+
+For per-sink status, Tier-2 SHOULD provide:
+
+- `exporter_name`
+- `sink_type`
+- `delivery_status`
+- `attempt_count`
+- `last_attempt_at`
+- `sink_ack_id`
+- `error_code`
+- `error_message`
+
+## Retry Guidance
+
+Clients SHOULD use `retry_after` when present.
+
+Tier-1 SDK/exporter implementations SHOULD treat retryability as follows:
+
+- retryable by default: `202`, `429`, `503`.
+- generally non-retryable: `400`, `401`, `403`, `409`, `413`.
+
+`500` retry behavior is implementation and policy dependent.
+
+## Security Requirements
+
+Tier-2 ingress MUST require secure transport and SHOULD support:
+
+- TLS with server authentication.
+- mTLS for stronger client identity where required.
+- TLS with token-based authentication where mTLS is not used.
+
+Tier-2 SHOULD validate integrity fields (`hash`, `signature` or `hmac`) per
+configured verification policy.
+
+## References
+
+- [Audit Logs Data Model](./data-model.md)
+- [Audit Logs Tier-1 API](./tier1-api.md)
+- [Audit Logs SDK](./sdk.md)


### PR DESCRIPTION
Introduces a new auditlogs specification area and defines Tier-1 and Tier-2 audit logging contracts based on the provided Tier-1/Tier-2 proposal docs.

Added new auditlogs spec documents
specification/auditlogs/data-model.md
Defines the audit log data model, required/optional fields, integrity fields (hash, signature/hmac), optional hash-chain fields, Tier-1 response model, Tier-2 verification/delivery statuses, and Tier-2 lifecycle states.
specification/auditlogs/sdk.md
Defines Tier-1 SDK behavior for audit records: provider/logger/processor/exporter contracts, processing modes (single sync, single async, batch async), response interpretation, and durability fallback semantics (persist to storage when immediate send/export is not possible).
specification/auditlogs/tier1-api.md
Defines Tier-1 application/SDK API surface for emitting audit records and checking Enabled.
specification/auditlogs/tier2-api.md
Defines Tier-2 auditLog ingress endpoint semantics: request/response model, domain statuses, HTTP mappings, idempotency/duplicate handling, verification and per-sink delivery semantics, retry guidance, and security requirements.
Naming/structure updates
Renamed the original audit API doc from api.md to tier1-api.md so Tier-1 scope is explicit.
Updated internal links in Tier-2 spec to reference tier1-api.md.
For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).


Related issues #<issue-number>

Related
[OTEP(s)](https://github.com/open-telemetry/oteps)
#<otep-number(s)>

Links to the prototypes (when adding or changing features)

[CHANGELOG.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md)
file updated for non-trivial changes
For trivial changes, include [chore] in the PR title to skip the changelog check

[Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml)
updated if necessary

[Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview)
